### PR TITLE
Fix dependency versions

### DIFF
--- a/routing-filter.gemspec
+++ b/routing-filter.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
 
-  s.add_dependency 'actionpack'
+  s.add_dependency 'actionpack', '>= 0'
 
-  s.add_development_dependency 'i18n'
-  s.add_development_dependency 'rails'
-  s.add_development_dependency 'test_declarative'
+  s.add_development_dependency 'i18n', '>= 0'
+  s.add_development_dependency 'rails', '>= 0'
+  s.add_development_dependency 'test_declarative', '>= 0'
 end


### PR DESCRIPTION
I'm trying to use this with an old project on Rails 2.3.4. I put this in the environment.rb:

```
config.gem 'routing-filter'
```

And it proceeds to install the following gems as dependencies:

```
Successfully installed routing-filter-0.2.3
Successfully installed activesupport-3.0.3
Successfully installed activemodel-3.0.3
Successfully installed rack-1.2.1
Successfully installed rack-test-0.5.7
Successfully installed rack-mount-0.6.13
Successfully installed tzinfo-0.3.24
Successfully installed abstract-1.0.0
Successfully installed erubis-2.6.6
```

It seems to be requiring the latest actionpack gem, which then installs all of these other gems. The gem dependencies for routing-filter say actionpack >= 0, so why isn't it using actionpack-2.3.4 which is already installed?

I suppose I could start using Bundler with this project, but I didn't want to start mucking around with our deployment scripts and whatnot on this project and the way gems are installed on the server.

I'm guessing that in the .gemspec file, the ">= 0" part needs to be specified, so here is a pull-request with those changes.
