### PR TITLE
Deprecation Warning in Rails 2.3.11

### DIFF
--- a/lib/routing_filter/adapters/rails_2.rb
+++ b/lib/routing_filter/adapters/rails_2.rb
@@ -15,7 +15,7 @@ ActionController::Routing::RouteSet::NamedRouteCollection.class_eval do
     if match = code.match(%r(^return (.*) if (.*)))
       # returned string must not contain newlines, or we'll spill out of inline code comments in
       # ActionController::Routing::RouteSet::NamedRouteCollection#define_url_helper
-      "returning(#{match[1]}) { |result|" +
+      (ActionPack::VERSION::MINOR >=3 && ActionPack::VERSION::TINY >=11 ? "#{match[1]}.tap { |result|" : "returning(#{match[1]}) { |result|") +
       "  ActionController::Routing::Routes.filters.run(:around_generate, *args, &lambda{ result }) " +
       "} if #{match[2]}"
     end


### PR DESCRIPTION
We just upgraded to Rails 2.3.11 and noticed that Kernel#returning has been deprecated in favor of Object#tap.  This looks at the minor and tiny version numbers for actionpack and decides which one to use in the rails_2.rb adapter.
