### PR TITLE
Using 'tap' instead of 'returning'

### DIFF
--- a/lib/routing_filter/adapters/rails_2.rb
+++ b/lib/routing_filter/adapters/rails_2.rb
@@ -15,7 +15,7 @@ ActionController::Routing::RouteSet::NamedRouteCollection.class_eval do
     if match = code.match(%r(^return (.*) if (.*)))
       # returned string must not contain newlines, or we'll spill out of inline code comments in
       # ActionController::Routing::RouteSet::NamedRouteCollection#define_url_helper
-      "returning(#{match[1]}) { |result|" +
+      "#{match[1]}.tap { |result|" +
       "  ActionController::Routing::Routes.filters.run(:around_generate, *args, &lambda{ result }) " +
       "} if #{match[2]}"
     end


### PR DESCRIPTION
Hi guys,

We're using routing-filter on a Rails 2 app, and it's working very well. When we upgraded to 2.3.11, though, we started getting a bunch of warnings since routing-filter calls 'returning', which has been deprecated. This patch replaces the call with a call to 'tap'.

Thanks,
David
