### PR TITLE
Add support for blockless calls to Rack::Mount::RouteSet#recognize

### DIFF
--- a/lib/routing_filter/adapters/rails_3.rb
+++ b/lib/routing_filter/adapters/rails_3.rb
@@ -71,7 +71,13 @@ Rack::Mount::CodeGeneration.class_eval do
     end
 
     request.env['PATH_INFO'] = original_path # hmm ...
-    block.call(route, matches, params) if route
+    return nil unless route
+
+    if block
+      return block.call(route, matches, params)
+    else
+      return route, matches, params
+    end
   end
 end
 


### PR DESCRIPTION
The original function supports both styles - this just keeps the patched version in sync to support dependencies that utilize that route
