### PR TITLE
Fix "ArgumentError: wrong number of arguments (2 for 0)" on Rails 2.3.14

### DIFF
--- a/lib/routing_filter/filters/extension.rb
+++ b/lib/routing_filter/filters/extension.rb
@@ -25,7 +25,7 @@ module RoutingFilter
 
     def around_recognize(path, env, &block)
       extract_extension!(path) unless excluded?(path)
-      yield(path, env)
+      yield
     end
 
     def around_generate(params, &block)

--- a/lib/routing_filter/filters/pagination.rb
+++ b/lib/routing_filter/filters/pagination.rb
@@ -26,7 +26,7 @@ module RoutingFilter
 
     def around_recognize(path, env, &block)
       page = extract_segment!(PAGINATION_SEGMENT, path)
-      yield(path, env).tap do |params|
+      yield.tap do |params|
         params[:page] = page.to_i if page
       end
     end


### PR DESCRIPTION
This makes all tests pass again on Rails 2.3.14 (using Ruby 1.9.2-p290)
