### PR TITLE
Regex.escape Mime.EXTENSION_LOOKUP.keys

### DIFF
--- a/lib/routing_filter/filters/extension.rb
+++ b/lib/routing_filter/filters/extension.rb
@@ -64,7 +64,7 @@ module RoutingFilter
       end
       
       def mime_extension?(url)
-        url =~ /\.#{Mime::EXTENSION_LOOKUP.keys.join('|')}(\?|$)/
+        url =~ /\.#{Mime::EXTENSION_LOOKUP.keys.map { |ext| Regexp.escape(ext) }.join('|')}(\?|$)/
       end
   end
 end


### PR DESCRIPTION
Prevent all pages breaking when weird mime extensions gets into Mime.EXTENSION_LOOKUP
Fixes:

    in routing_filter/filters/extension.rb:  67:in `mime_extension?'
    RegexpError: unmatched close parenthesis: /\.all|text|txt|html|xhtml|js|css|ics|csv|xml|rss|atom|yaml|multipart_form|url_encoded_form|json|aspx|htmlbefore|html)|htm|html+++++++++++++++++++Result:+chosen+nickname+"wyduxxgs";+success+(from+first+page);(\?|$)/`

Will submit an issue to Rails 2.3.14 as of how these weird Mime type extensions could sneak into Mime.EXTENSION_LOOKUP

**UPDATE:** opened issue in rails issue tracker: https://github.com/rails/rails/issues/7248 