### PR TITLE
request.path did not work any more

### DIFF
--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -17,7 +17,12 @@ ActionDispatch::Journey::Router.class_eval do
     find_routes_without_filtering(env).map do |match, parameters, route|
       [ match, parameters.merge(filter_parameters), route ]
     end.tap do |match, parameters, route|
-      env['PATH_INFO'] = original_path # restore the original path
+      # restore the original path
+      if env.is_a?(Hash)
+        env['PATH_INFO'] = original_path
+      else
+        env.path_info = original_path
+      end
     end
   end
   alias_method_chain :find_routes, :filtering

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -81,4 +81,15 @@ class RailsTest < Minitest::Test
     assert_equal uuid, params[:uuid]
     assert_equal "/en/#{uuid}/foo/1.html", params[:url]
   end
+
+  test "check request object" do
+    get "/de/foo/1"
+    assert_equal "/de/foo/1", last_request.path
+
+    get "/foo/1"
+    assert_equal "/foo/1", last_request.path
+
+    get "/de/foo/1?bar=baz"
+    assert_equal "/de/foo/1?bar=baz", last_request.fullpath
+  end
 end


### PR DESCRIPTION
request.path (which is used by current_url?) did not work any more (I think it's the same like in issue #7 again). Here is the fix. I hope the test is in the right place. Thank you for this awesome gem!