### PR TITLE
Adding the license information to the gemspec

### DIFF
--- a/routing-filter.gemspec
+++ b/routing-filter.gemspec
@@ -6,6 +6,7 @@ rails_version = ['>= 6.1']
 Gem::Specification.new do |s|
   s.name         = "routing-filter"
   s.version      = RoutingFilter::VERSION
+  s.license      = "MIT"
   s.authors      = ["Sven Fuchs"]
   s.email        = "svenfuchs@artweb-design.de"
   s.homepage     = "http://github.com/svenfuchs/routing-filter"


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance analysis.