### PR TITLE
Journey parameters

### DIFF
--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -8,7 +8,7 @@ module ActionDispatchJourneyRouterWithFiltering
       filter_parameters
     end
 
-    super(env).map do |match, parameters={}, route|
+    super(env).map do |match, parameters, route|
       [ match, parameters.merge(filter_parameters), route ]
     end.tap do |match, parameters, route|
       # restore the original path

--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -8,7 +8,7 @@ module ActionDispatchJourneyRouterWithFiltering
       filter_parameters
     end
 
-    super(env).map do |match, parameters, route|
+    super(env).map do |match, parameters={}, route|
       [ match, parameters.merge(filter_parameters), route ]
     end.tap do |match, parameters, route|
       # restore the original path


### PR DESCRIPTION
Running with Rails 7.1.3 and testing an active storage route I have been getting
```
   NoMethodError:
       undefined method `merge' for nil:NilClass
     # ./vendor/cache/ruby/3.2.0/gems/routing-filter-0.7.0/lib/routing_filter/adapters/routers/journey.rb:13:in `block in find_routes'
     # ./vendor/cache/ruby/3.2.0/gems/routing-filter-0.7.0/lib/routing_filter/adapters/routers/journey.rb:11:in `map'
     # ./vendor/cache/ruby/3.2.0/gems/routing-filter-0.7.0/lib/routing_filter/adapters/routers/journey.rb:11:in `find_routes'
```

Adding a default value of {} to parameters  fixed this