### PR TITLE
make compatible with rails 7.1 (most likely will break for previous v…

### DIFF
--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -8,15 +8,16 @@ module ActionDispatchJourneyRouterWithFiltering
       filter_parameters
     end
 
-    super(env).map do |match, parameters, route|
-      [ match, parameters.merge(filter_parameters), route ]
-    end.tap do |match, parameters, route|
-      # restore the original path
+    super(env) do |match, parameters, route|
+      parameters = parameters.merge(filter_parameters)
+
       if env.is_a?(Hash)
         env['PATH_INFO'] = original_path
       else
         env.path_info = original_path
       end
+
+      yield [match, parameters, route]
     end
   end
 end

--- a/routing-filter.gemspec
+++ b/routing-filter.gemspec
@@ -1,7 +1,7 @@
 $:.unshift File.expand_path('../lib', __FILE__)
 require 'routing_filter/version'
 
-rails_version = ['>= 6.1']
+rails_version = ['>= 7.1']
 
 Gem::Specification.new do |s|
   s.name         = "routing-filter"


### PR DESCRIPTION
This seems to work fine in our project for filters to work again with rails >= 7.1.

Maybe I'll have the time to properly implement this with backwards compatibility.

For now this might help others :) 

Should address this issue
https://github.com/svenfuchs/routing-filter/issues/83